### PR TITLE
Yt2article background overflow

### DIFF
--- a/src/components/yt2article/ArticleView.tsx
+++ b/src/components/yt2article/ArticleView.tsx
@@ -71,10 +71,10 @@ const ArticleView: FC<ArticleViewProps> = ({
     <div className={`min-h-screen ${bgClass} transition-colors duration-300`}>
       {/* Header with controls */}
       <div
-        className={`sticky top-0 z-10 border-b bg-opacity-90 backdrop-blur-sm ${borderClass} ${bgClass}`}
+        className={`sticky top-0 z-10 w-full border-b bg-opacity-90 backdrop-blur-sm ${borderClass} ${bgClass}`}
       >
-        <div className="mx-auto flex max-w-3xl items-center justify-between px-6 py-4">
-          <div className="flex items-center gap-4">
+        <div className="mx-auto flex w-full max-w-3xl flex-col gap-3 px-4 py-4 sm:flex-row sm:items-center sm:justify-between sm:px-6">
+          <div className="flex flex-wrap items-center gap-3">
             <a
               href={`https://www.youtube.com/watch?v=${videoId}`}
               target="_blank"
@@ -89,12 +89,14 @@ const ArticleView: FC<ArticleViewProps> = ({
               </span>
             )}
           </div>
-          <div className="flex items-center gap-2">
-            <span className={`text-xs ${mutedClass}`}>{modelUsed}</span>
+          <div className="flex flex-wrap items-center gap-2 sm:justify-end">
+            <span className={`text-xs ${mutedClass} max-w-[10rem] truncate`} title={modelUsed}>
+              {modelUsed}
+            </span>
             {showRegenerateButton && !isStreaming && onRegenerateClick && (
               <button
                 onClick={onRegenerateClick}
-                className={`rounded-md px-3 py-2 text-sm transition-colors ${
+                className={`rounded-md px-2 py-1.5 text-xs transition-colors sm:px-3 sm:py-2 sm:text-sm ${
                   isDarkMode
                     ? "bg-slate-800 text-white hover:bg-slate-700"
                     : "bg-gray-200 text-gray-800 hover:bg-gray-300"
@@ -106,7 +108,7 @@ const ArticleView: FC<ArticleViewProps> = ({
             {showShareButton && !isStreaming && (
               <button
                 onClick={handleCopyLink}
-                className={`rounded-md px-3 py-2 text-sm transition-colors ${
+                className={`rounded-md px-2 py-1.5 text-xs transition-colors sm:px-3 sm:py-2 sm:text-sm ${
                   isDarkMode
                     ? "bg-slate-800 text-white hover:bg-slate-700"
                     : "bg-gray-200 text-gray-800 hover:bg-gray-300"
@@ -117,7 +119,7 @@ const ArticleView: FC<ArticleViewProps> = ({
             )}
             <button
               onClick={() => setIsDarkMode(!isDarkMode)}
-              className={`rounded-md px-3 py-2 text-sm transition-colors ${
+              className={`rounded-md px-2 py-1.5 text-xs transition-colors sm:px-3 sm:py-2 sm:text-sm ${
                 isDarkMode
                   ? "bg-slate-800 text-white hover:bg-slate-700"
                   : "bg-gray-200 text-gray-800 hover:bg-gray-300"

--- a/src/components/yt2article/ArticleView.tsx
+++ b/src/components/yt2article/ArticleView.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import type { FC } from "react";
 import { Streamdown } from "streamdown";
 
@@ -39,6 +39,18 @@ const ArticleView: FC<ArticleViewProps> = ({
   const shareUrl = typeof window !== "undefined"
     ? `${window.location.origin}/yt2article/view/${videoId}`
     : "";
+
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    document.documentElement.style.setProperty("--app-bg", isDarkMode ? "#111827" : "#ffffff");
+  }, [isDarkMode]);
+
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    return () => {
+      document.documentElement.style.removeProperty("--app-bg");
+    };
+  }, []);
 
   const handleCopyLink = async () => {
     try {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3,13 +3,17 @@
 @tailwind utilities;
 
 @layer base {
+  :root {
+    --app-bg: #111827;
+  }
+
   html {
-    background-color: #111827;
+    background-color: var(--app-bg);
   }
 
   body {
     min-height: 100%;
-    background-color: #111827;
+    background-color: var(--app-bg);
     overflow-x: hidden;
   }
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,3 +1,15 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  html {
+    background-color: #111827;
+  }
+
+  body {
+    min-height: 100%;
+    background-color: #111827;
+    overflow-x: hidden;
+  }
+}


### PR DESCRIPTION
Set global `html`/`body` background color and hid horizontal overflow to prevent white edges on mobile.

---
<a href="https://cursor.com/background-agent?bcId=bc-53020a00-74fb-4a7a-882c-7a9b0ff8cd6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-53020a00-74fb-4a7a-882c-7a9b0ff8cd6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves background handling and responsive header in the yt2article view.
> 
> - Defines `--app-bg` in `globals.css`, applies it to `html`/`body`, and hides horizontal overflow to prevent white edges
> - In `ArticleView.tsx`, syncs `--app-bg` with dark mode via `useEffect` and cleans it up on unmount
> - Refactors header layout: full-width sticky bar, responsive flex/wrapping, truncated `modelUsed`, and more compact buttons
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db14de72bd9e8be3d9b8554dc0b6c443ca43b7b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->